### PR TITLE
fix(input-component): Add missing name attribute and improve prop type safety

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -11,6 +11,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       className = "",
       placeholder,
       value,
+      name,
       defaultValue,
       onChange,
       ...props
@@ -24,6 +25,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         className={className}
         placeholder={placeholder}
         ref={ref}
+        name={name}
         value={value}
         defaultValue={defaultValue}
         onChange={onChange}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,59 +1,58 @@
 export interface BlogPost {
-    userId?: string;
-    id: string;
-    title: string;
-    body: string;
-    author: string | null | undefined;
-    createdAt?: Date;
-    updatedAt?: Date;
-    categories: { id: string; name: string }[];
+  userId?: string;
+  id: string;
+  title: string;
+  body: string;
+  author: string | null | undefined;
+  createdAt?: Date;
+  updatedAt?: Date;
+  categories: { id: string; name: string }[];
 }
 
 export interface Category {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 }
 
 export interface ButtonProps {
-    label?: string;
-    onClick?: () => void;
-    className?: string;
-    disabled?: boolean;
-    icon?: React.ReactNode;
-    type?: "button" | "submit" | "reset";
-    usePendingStatus?: boolean;
-    pendingContent?: string;
+  label?: string;
+  onClick?: () => void;
+  className?: string;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  type?: "button" | "submit" | "reset";
+  usePendingStatus?: boolean;
+  pendingContent?: string;
 }
 
 export interface InputProps {
-    className?: string;
-    variant?: "standard" | "outlined" | "static";
-    placeholder?: string;
-    id?: string;
-    type: string;
-    value?: string;
-    defaultValue?: string;
-    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    [key: string]: any;
+  className?: string;
+  variant?: "standard" | "outlined" | "static";
+  placeholder?: string;
+  id?: string;
+  type: string;
+  name: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export interface TextareaProps {
-    className: string;
-    id: string;
-    rows: number;
-    name: string;
-    value?: string;
-    onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void; // Include onChange prop
-    [key: string]: any;
+  className: string;
+  id: string;
+  rows: number;
+  name: string;
+  value?: string;
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export interface SiteConfigProps {
-    name: string;
-    description: string;
-    url: string;
-    og: string;
-    ogImage: string;
-    links: {
-        github: string;
-    }
+  name: string;
+  description: string;
+  url: string;
+  og: string;
+  ogImage: string;
+  links: {
+    github: string;
+  };
 }


### PR DESCRIPTION
- Added `name` attribute to `InputProps` interface and included it in the `Input` component to support form submissions and accessibility.
- Removed `[key: string]: any;` from `InputProps` and `TextareaProps` to enhance prop type safety and fix VSCode prop suggestion visibility issues.