### PR TITLE
feat(auth): Integrate AuthProvider wrapper using updated Kinde auth provider API

### DIFF
--- a/app/AuthProvider.tsx
+++ b/app/AuthProvider.tsx
@@ -1,0 +1,6 @@
+"use client";
+import { KindeProvider } from "@kinde-oss/kinde-auth-nextjs";
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  return <KindeProvider>{children}</KindeProvider>;
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/providers/ThemeProvider";
 import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "react-hot-toast";
 import { siteConfig } from "@/lib/siteConfig";
+import { AuthProvider } from "@/app/AuthProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -71,15 +72,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
-        <ThemeProvider>
-          <NextTopLoader showSpinner={false} color="#fff" />
-          <Toaster />
-          <Navbar />
-          {children}
-        </ThemeProvider>
-      </body>
-    </html>
+    <AuthProvider>
+      <html lang="en" suppressHydrationWarning>
+        <body className={inter.className}>
+          <ThemeProvider>
+            <NextTopLoader showSpinner={false} color="#fff" />
+            <Toaster />
+            <Navbar />
+            {children}
+          </ThemeProvider>
+        </body>
+      </html>
+    </AuthProvider>
   );
 }


### PR DESCRIPTION
- Added `AuthProvider` component using `KindeProvider` from @kinde-oss/kinde-auth-nextjs.
- Updated `RootLayout` to include `AuthProvider` at the root level.
- No changes to `authentication` logic; aligns with updated library documentation.