### PR TITLE
fix(profile): Ensure database record creation when updating bio and social links

### DIFF
--- a/actions/updateBioAndSocialLinks.ts
+++ b/actions/updateBioAndSocialLinks.ts
@@ -6,22 +6,34 @@ interface UpdateBioAndSocialLinksParams {
   userId: string;
   bio?: string;
   socialLinks?: string;
+  name?: string;
+  familyName?: string;
+  email?: string;
 }
 
 export async function updateBioAndSocialLinks({
   userId,
   bio,
   socialLinks,
+  name,
+  familyName,
+  email,
 }: UpdateBioAndSocialLinksParams) {
   try {
-    const updatedUser = await prisma.user.update({
+    const user = await prisma.user.upsert({
       where: { id: userId },
-      data: {
-        bio,
-        socialLinks,
+      update: { bio, socialLinks },
+      create: {
+        id: userId,
+        name: name || "Unknown",
+        email: email || "unknown@example.com",
+        familyName: familyName || "Unknown",
+        bio: bio || null,
+        socialLinks: socialLinks || null,
       },
     });
-    return updatedUser;
+
+    return user;
   } catch (error) {
     console.error("Failed to update bio and social links:", error);
     throw new Error("Could not update bio and social links.");

--- a/components/UserProfileForm.tsx
+++ b/components/UserProfileForm.tsx
@@ -45,7 +45,8 @@ const UserProfileForm = ({
   };
 
   const handleSubmit = async () => {
-    const { given_name, family_name, picture, bio, socialLinks } = formData;
+    const { given_name, family_name, picture, bio, socialLinks, email } =
+      formData;
 
     const needsApiUpdate =
       given_name !== user?.given_name ||
@@ -76,6 +77,9 @@ const UserProfileForm = ({
           userId: formData.provided_id,
           bio,
           socialLinks,
+          name: given_name,
+          familyName: family_name,
+          email,
         });
 
         setFormData((prev) => ({


### PR DESCRIPTION
- Fixed an issue where updating bio and social links failed to create a user record in the database if one didn't exist.
- Enhanced logic in `updateBioAndSocialLinks` to check for the user's record and create it if necessary.
- Maintained compatibility with the new fields (`name`, `familyName`, `email`).

BREAKING CHANGE: `updateBioAndSocialLinks` now includes logic that enforces the creation of user records if absent, requiring additional database operations.