### PR TITLE
feat(ui): Update 404 NotFound page layout and styling

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,25 +3,32 @@ import Button from "@/components/Button";
 
 const NotFound = () => {
   return (
-    <div className="mt-36 px-4 dark:bg-gray-900">
+    <main className="grid min-h-full place-items-center px-6 py-24 sm:py-32 lg:px-8">
       <div className="text-center">
-        <h1 className="text-9xl font-black text-white">404</h1>
-
-        <p className="text-2xl font-bold tracking-tight text-gray-300 sm:text-4xl">
-          Uh-oh!
+        <p className="text-base font-semibold text-indigo-600">404</p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight dark:text-white sm:text-5xl">
+          Page not found
+        </h1>
+        <p className="mt-6 text-base leading-7 dark:text-white">
+          Sorry, we couldn’t find the page you’re looking for.
         </p>
-
-        <p className="mt-4 text-gray-300">We can't find that page.</p>
-
-        <Link href="/">
-          <Button
-            type="button"
-            label="Go Back Home"
-            className="text-white border-white font-Archivo rounded-full  mt-6 font-extralight"
-          />
-        </Link>
+        <div className="mt-10 flex items-center justify-center gap-x-6">
+          <Link
+            href="/"
+            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 duration-300"
+          >
+            Go back home
+          </Link>
+          <Link
+            href="https://github.com/itsteatv"
+            target="_blank"
+            className="text-sm font-semibold dark:text-white"
+          >
+            Contact support <span aria-hidden="true">&rarr;</span>
+          </Link>
+        </div>
       </div>
-    </div>
+    </main>
   );
 };
 


### PR DESCRIPTION
- Updated the 404 NotFound page to use a modern layout with a grid and centered design.
- Changed the headline to a more user-friendly "Page not found" message.
- Replaced the old button with new buttons styled for better user experience:

  - "Go back home" with hover and focus-visible effects.
  - Added a "Contact support" link pointing to GitHub support.