### PR TITLE
feat(Button): Add loading state and customizable loading component

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -12,9 +12,20 @@ const Button = ({
   icon,
   usePendingStatus = false,
   pendingContent = "Processing...",
+  isLoading = false,
+  loadingComponent,
 }: ButtonProps) => {
   const { pending } = useFormStatus();
-  const displayContent = usePendingStatus && pending ? pendingContent : label;
+  const showLoading = (usePendingStatus && pending) || isLoading;
+
+  const displayContent = showLoading ? (
+    <div className="relative flex items-center space-x-2">
+      {loadingComponent}
+      <span>{pendingContent}</span>
+    </div>
+  ) : (
+    label
+  );
 
   return (
     <button
@@ -23,7 +34,7 @@ const Button = ({
       disabled={disabled || pending}
       onClick={onClick}
     >
-      {icon && icon}
+      {icon && <span>{icon}</span>}
       {displayContent}
     </button>
   );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,8 @@ export interface ButtonProps {
   type?: "button" | "submit" | "reset";
   usePendingStatus?: boolean;
   pendingContent?: string;
+  isLoading?: boolean;
+  loadingComponent?: React.ReactNode;
 }
 
 export interface InputProps {


### PR DESCRIPTION
- Added `isLoading` prop to control loading state externally.
- Added `loadingComponent` prop for custom loading spinner or content.
- Updated `Button` component to conditionally render a loading state.
- Display `pendingContent` or custom `loadingComponent` during loading.
- Adjusted button to show the loading state if `isLoading` or form is pending.

BREAKING CHANGE: `ButtonProps` interface updated with new `isLoading` and `loadingComponent` props.
