### PR TITLE
chore(security): Remove Content-Security-Policy header from dashboard

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,10 +19,6 @@ const nextConfig = {
         source: "/dashboard(.*)",
         headers: [
           {
-            key: "Content-Security-Policy",
-            value: `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self'; font-src 'self'; object-src 'none'; frame-ancestors 'none';`,
-          },
-          {
             key: "Strict-Transport-Security",
             value: "max-age=31536000; includeSubDomains; preload",
           },


### PR DESCRIPTION
Removed the Content-Security-Policy header from the /dashboard route as it was preventing fonts from being loaded from external sources.