### PR TITLE
feat(layout): Add touch-pan directives to prevent zooming on mobile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,7 +73,11 @@ export default function RootLayout({
 }>) {
   return (
     <AuthProvider>
-      <html lang="en" suppressHydrationWarning>
+      <html
+        className="touch-pan-x touch-pan-y"
+        lang="en"
+        suppressHydrationWarning
+      >
         <body className={inter.className}>
           <ThemeProvider>
             <NextTopLoader showSpinner={false} color="#fff" />


### PR DESCRIPTION
- Added `touch-pan-x` and `touch-pan-y` classes to the `<html>` tag in `RootLayout` to disable pinch-to-zoom behavior on mobile devices.