### PR TITLE
feat(sitemap): Integrate dynamic post URLs into sitemap generation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,16 +1,32 @@
-import { MetadataRoute } from "next";
+import { fetchPosts } from "@/actions/fetchPosts";
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const staticPages = [
-    {
-      url: "https://your-production-domain.com/about",
-      lastModified: new Date(),
-    },
-    {
-      url: "https://your-production-domain.com/contact",
-      lastModified: new Date(),
-    },
-  ];
+export default async function sitemap() {
+  try {
+    const allPosts = await fetchPosts(0, Number.MAX_SAFE_INTEGER);
 
-  return [...staticPages];
+    const postSitemap = allPosts.map((post) => ({
+      url: `${process.env.SITE_URL}/blog/${post.id}`,
+      lastModified: new Date(post.updatedAt).toISOString(),
+    }));
+
+    const staticRoutes = [
+      {
+        url: `${process.env.SITE_URL}/blog`,
+        lastModified: new Date().toISOString(),
+      },
+      {
+        url: `${process.env.SITE_URL}/contact`,
+        lastModified: new Date().toISOString(),
+      },
+      {
+        url: `${process.env.SITE_URL}/about`,
+        lastModified: new Date().toISOString(),
+      },
+    ];
+
+    return [...staticRoutes, ...postSitemap];
+  } catch (error) {
+    console.error("Failed to generate sitemap:", error);
+    throw new Error("Failed to generate sitemap");
+  }
 }


### PR DESCRIPTION
- Replaced static sitemap entries with dynamically fetched blog post URLs.
- Added error handling to ensure sitemap generation robustness.
- Incorporated `fetchPosts` to retrieve all posts for dynamic mapping.
- Maintained static routes for `blog`, `contact`, and `about` pages.