### PR TITLE
feat(seo): Add robots.txt configuration for site accessibility

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin", "/dashboard", "create-post"],
+      },
+    ],
+    sitemap: `${process.env.SITE_URL}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
- Implemented `robots.txt` configuration using MetadataRoute.Robots
- Added rules to allow access to all pages except /admin, /dashboard, and /create-post
- Dynamically included `sitemap` URL from environment variables