### PR TITLE
feat(metadata): Add metadata configuration for admin and other pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,12 @@
-"use client";
-
 import Image from "next/image";
 import boyIllustration from "@/public/boyIllustration.svg";
 import Link from "next/link";
 import Button from "@/components/Button";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+};
 
 const About = () => {
   return (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,14 @@
 import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
 import { redirect } from "next/navigation";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 const Admin = async () => {
   const { isAuthenticated, getPermission } = getKindeServerSession();

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from "react";
 import PostsList from "@/components/PostsList";
 import Loading from "./loading";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Blog",
+};
 
 const Blog = () => {
   return (

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,4 +1,9 @@
 import ContactForm from "@/components/ContactForm";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact",
+};
 
 const Contact = () => {
   return <ContactForm />;

--- a/app/create-post/page.tsx
+++ b/app/create-post/page.tsx
@@ -1,6 +1,11 @@
 import CreatePostForm from "@/components/CreatePostForm";
 import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
 import { redirect } from "next/navigation";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Create-Post",
+};
 
 const CreatePost = async () => {
   const { isAuthenticated, getUser, getPermission } = getKindeServerSession();

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,15 @@ import { getKindeServerSession } from "@kinde-oss/kinde-auth-nextjs/server";
 import { redirect } from "next/navigation";
 import prisma from "@/lib/db";
 import UserProfileForm from "@/components/UserProfileForm";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 const Dashboard = async () => {
   const { getUser, isAuthenticated } = getKindeServerSession();


### PR DESCRIPTION
- Added `metadata` configuration to admin and other pages for improved SEO and control.
- Configured `title` and `robots` properties to prevent indexing and following on the Admin page.
- Ensured consistent updates across related pages.