### PR TITLE
fix(navbar): Update create-post link to support internationalization

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -115,7 +115,7 @@ export default function Navbar({ locale }: { locale: string }) {
           <div className="flex items-center">
             {isAuthenticated ? (
               <>
-                <Link href="/create-post">
+                <Link href={`/${locale}/create-post`}>
                   <div className="flex flex-row">
                     <Button
                       type="button"


### PR DESCRIPTION
Updated the `create-post` link in the navbar to include locale-based URLs, ensuring proper functionality with internationalization.