### PR TITLE
feat(auth): Improve OTP verification flow with locale-based redirection

### DIFF
--- a/app/[locale]/auth/confirm/route.ts
+++ b/app/[locale]/auth/confirm/route.ts
@@ -1,14 +1,21 @@
 import { type EmailOtpType } from "@supabase/supabase-js";
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/";
+  const redirectTo = request.nextUrl.clone();
+  redirectTo.pathname = next;
+
+  const headersList = headers();
+  const pathname = headersList.get("next-url") || "/en";
+  const locale = pathname.split("/")[1] || "en";
 
   if (token_hash && type) {
     const supabase = await createClient();
@@ -24,5 +31,6 @@ export async function GET(request: NextRequest) {
   }
 
   // redirect the user to an error page with some instructions
-  redirect("/error");
+  redirectTo.pathname = `${origin}/${locale}/auth/auth-code-error`;
+  return NextResponse.redirect(redirectTo);
 }


### PR DESCRIPTION
- Use `NextResponse` for handling redirects  
- Extract locale from headers to support localized error pages  
- Modify redirect logic to include locale in error URL  
- Ensure redirection to user-specified `next` path when OTP verification succeeds