### PR TITLE
refactor(auth): Rename login route to signIn for consistency

### DIFF
--- a/app/[locale]/auth/confirm/route.ts
+++ b/app/[locale]/auth/confirm/route.ts
@@ -1,14 +1,21 @@
 import { type EmailOtpType } from "@supabase/supabase-js";
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/";
+  const redirectTo = request.nextUrl.clone();
+  redirectTo.pathname = next;
+
+  const headersList = headers();
+  const pathname = headersList.get("next-url") || "/en";
+  const locale = pathname.split("/")[1] || "en";
 
   if (token_hash && type) {
     const supabase = await createClient();
@@ -24,5 +31,6 @@ export async function GET(request: NextRequest) {
   }
 
   // redirect the user to an error page with some instructions
-  redirect("/error");
+  redirectTo.pathname = `${origin}/${locale}/auth/auth-code-error`;
+  return NextResponse.redirect(redirectTo);
 }

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -43,7 +43,7 @@ export async function updateSession(request: NextRequest) {
   const locale = pathnameParts[1];
 
   const publicRoutes = [
-    "/login",
+    "/signIn",
     "/register",
     "/forgot-password",
     "/reset-password",
@@ -56,7 +56,7 @@ export async function updateSession(request: NextRequest) {
 
   if (!user && !isPublicRoute) {
     const url = request.nextUrl.clone();
-    url.pathname = `/${locale}/login`;
+    url.pathname = `/${locale}/signIn`;
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
- Update public route `/login` to `/signIn`  
- Ensure redirection aligns with the new `/signIn` route  
- Maintain session handling and `Supabase authentication` logic