### PR TITLE
feat(auth): Refactor ResetPassword form to use external validation schemas

### DIFF
--- a/components/Auth/ResetPassword.tsx
+++ b/components/Auth/ResetPassword.tsx
@@ -1,55 +1,52 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { resetPassword } from "@/actions/auth";
 import toast from "react-hot-toast";
-
-const formSchema = z
-  .object({
-    password: z.string().min(6, "Password must be at least 6 characters"),
-    passwordConfirm: z
-      .string()
-      .min(6, "Password confirmation must be at least 6 characters"),
-  })
-  .refine((data) => data.password === data.passwordConfirm, {
-    message: "Passwords do not match",
-    path: ["passwordConfirm"],
-  });
+import {
+  passwordMatchSchema,
+  TPasswordMatchSchema,
+} from "@/schemas/passwordMatchSchema";
 
 const ResetPassword = () => {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const pathname = usePathname();
+  const locale = pathname.split("/")[1] || "en";
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<TPasswordMatchSchema>({
+    resolver: zodResolver(passwordMatchSchema),
     defaultValues: {
       password: "",
       passwordConfirm: "",
     },
   });
 
-  const handleSubmit = async (data: z.infer<typeof formSchema>) => {
+  const handleFormSubmit = async (data: TPasswordMatchSchema) => {
     setError(null);
     setLoading(true);
 
     try {
-      const response = await resetPassword(
-        {
-          password: data.password,
-          passwordConfirm: data.passwordConfirm,
-        },
-      );
+      const response = await resetPassword({
+        password: data.password,
+        passwordConfirm: data.passwordConfirm,
+      });
 
       if (response.error) {
         setError(response.message);
       } else {
-        toast.success("Passwor`d successfully reset!");
-        router.replace("/login");
+        toast.success("Password successfully reset!");
+        reset();
+        router.replace(`/${locale}/blog`);
       }
     } catch (error) {
       setError("An unexpected error occurred. Please try again.");
@@ -62,7 +59,7 @@ const ResetPassword = () => {
     <div className="sm:max-w-smd mx-auto flex items-center justify-center min-h-screen">
       <div className="p-8 rounded-lg shadow-lg w-full max-w-sm">
         <h2 className="text-2xl font-bold text-center mb-6">Reset Password</h2>
-        <form onSubmit={form.handleSubmit(handleSubmit)}>
+        <form onSubmit={handleSubmit(handleFormSubmit)}>
           {/* Password Input */}
           <div className="w-full mb-4">
             <div className="input-group w-full">
@@ -70,15 +67,15 @@ const ResetPassword = () => {
                 <span className="icon-[solar--lock-password-bold-duotone] text-base-content/80 size-5"></span>
               </span>
               <input
-                {...form.register("password")}
+                {...register("password")}
                 type="password"
                 className="input max-w-sm"
                 placeholder="Enter your new password"
               />
             </div>
-            {form.formState.errors.password && (
+            {errors.password && (
               <p className="text-red-500 text-sm mt-1">
-                {form.formState.errors.password.message}
+                {errors.password.message}
               </p>
             )}
           </div>
@@ -90,15 +87,15 @@ const ResetPassword = () => {
                 <span className="icon-[solar--lock-password-bold-duotone] text-base-content/80 size-5"></span>
               </span>
               <input
-                {...form.register("passwordConfirm")}
+                {...register("passwordConfirm")}
                 type="password"
                 className="input max-w-sm"
                 placeholder="Confirm your password"
               />
             </div>
-            {form.formState.errors.passwordConfirm && (
+            {errors.passwordConfirm && (
               <p className="text-red-500 text-sm mt-1">
-                {form.formState.errors.passwordConfirm.message}
+                {errors.passwordConfirm.message}
               </p>
             )}
           </div>

--- a/schemas/passwordMatchSchema.ts
+++ b/schemas/passwordMatchSchema.ts
@@ -15,3 +15,5 @@ export const passwordMatchSchema = z
       });
     }
   });
+
+export type TPasswordMatchSchema = z.infer<typeof passwordMatchSchema>;


### PR DESCRIPTION
- Replaced inline Zod validation with modular password validation schemas.
- Imported `passwordMatchSchema` and `TPasswordMatchSchema` from `passwordMatchSchema.ts`.
- Ensured password validation consistency across authentication forms.
- Improved maintainability and reusability of validation logic.

BREAKING CHANGE: This update modifies the password validation structure, requiring the new schema imports.