### PR TITLE
feat(auth): Add social login options to dashboard

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -148,6 +148,81 @@ export async function signInWithGithub() {
   }
 }
 
+export async function signInWithGoogle() {
+  const headersList = headers();
+  const pathname = headersList.get("next-url") || "/en";
+  const locale = pathname.split("/")[1] || "en";
+
+  const origin = await headers().get("origin");
+
+  const redirectUrl = `${origin}/${locale}/auth/callback?next=${pathname}`;
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: redirectUrl,
+    },
+  });
+
+  if (error) {
+    redirect(`${locale}/error`);
+  } else if (data.url) {
+    return redirect(data.url);
+  }
+}
+
+export async function signInWithFacebook() {
+  const headersList = headers();
+  const pathname = headersList.get("next-url") || "/en";
+  const locale = pathname.split("/")[1] || "en";
+
+  const origin = await headers().get("origin");
+
+  const redirectUrl = `${origin}/${locale}/auth/callback?next=${pathname}`;
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "facebook",
+    options: {
+      redirectTo: redirectUrl,
+    },
+  });
+
+  if (error) {
+    redirect(`${locale}/error`);
+  } else if (data.url) {
+    return redirect(data.url);
+  }
+}
+
+export async function signInWithDiscord() {
+  const headersList = headers();
+  const pathname = headersList.get("next-url") || "/en";
+  const locale = pathname.split("/")[1] || "en";
+
+  const origin = await headers().get("origin");
+
+  const redirectUrl = `${origin}/${locale}/auth/callback?next=${pathname}`;
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "discord",
+    options: {
+      redirectTo: redirectUrl,
+    },
+  });
+
+  if (error) {
+    redirect(`${locale}/error`);
+  } else if (data.url) {
+    return redirect(data.url);
+  }
+}
+
 export const forgotPassword = async ({ email }: { email: string }) => {
   const forgotPasswordValidation = forgotPasswordSchema.safeParse({
     email,

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -4,6 +4,10 @@ import { getTranslations } from "next-intl/server";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import GoogleLogin from "@/components/Auth/GoogleLogin";
+import FacebookLogin from "@/components/Auth/FacebookLogin";
+import DiscordLogin from "@/components/Auth/DiscordLogin";
+import { getLinkedStatus } from "@/utils/getLinkedStatus";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -28,16 +32,19 @@ const Dashboard = async () => {
 
   const user = data?.user;
 
+  const {
+    google: isGoogleLinked,
+    facebook: isFacebookLinked,
+    discord: isDiscordLinked,
+  } = getLinkedStatus(data.user.identities);
+
   return (
     <div className="divide-y divide-white/5">
       <div className="flex mx-auto max-w-2xl gap-x-8 gap-y-10 py-16 px-4 sm:px-6 flex-col lg:px-8">
         <div className="px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-semibold dark:text-white leading-tight">
-            {t("personalInfo.title")}
+          <h2 className="text-2xl font-semibold text-primary leading-tight">
+            Welcome @{user?.user_metadata?.username || "User"}
           </h2>
-          <p className="mt-1 text-sm leading-6 dark:text-gray-400">
-            {t("personalInfo.description")}
-          </p>
 
           {user?.new_email && (
             <div className="bg-primary-content text-primary p-4 rounded mt-7">
@@ -45,6 +52,14 @@ const Dashboard = async () => {
             </div>
           )}
         </div>
+
+        {(!isGoogleLinked || !isFacebookLinked || !isDiscordLinked) && (
+          <div className="mt-4 flex flex-col gap-2  px-4 sm:px-6 lg:px-8">
+            {!isGoogleLinked && <GoogleLogin />}
+            {!isFacebookLinked && <FacebookLogin />}
+            {!isDiscordLinked && <DiscordLogin />}
+          </div>
+        )}
 
         <div className="md:col-span-2">
           <UserProfileForm user={data?.user} />

--- a/components/Auth/DiscordLogin.tsx
+++ b/components/Auth/DiscordLogin.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { signInWithDiscord } from "@/actions/auth";
+import React, { useTransition } from "react";
+
+const DiscordLogin = () => {
+  const [isPending, startTransition] = useTransition();
+
+  const handleLogin = () => {
+    startTransition(async () => {
+      await signInWithDiscord();
+    });
+  };
+
+  return (
+    <div
+      onClick={handleLogin}
+      className="btn btn-block mt-2 border-[#5865F2] bg-[#5865F2] text-white shadow-[#5865F2]/30 hover:bg-[#5865F2]/90"
+    >
+      <span className="icon-[tabler--brand-discord]"></span>
+      {isPending ? "Redirecting..." : "Connect Discord"}
+    </div>
+  );
+};
+
+export default DiscordLogin;

--- a/components/Auth/FacebookLogin.tsx
+++ b/components/Auth/FacebookLogin.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { signInWithFacebook } from "@/actions/auth";
+import React, { useTransition } from "react";
+
+const FacebookLogin = () => {
+  const [isPending, startTransition] = useTransition();
+
+  const handleLogin = () => {
+    startTransition(async () => {
+      await signInWithFacebook();
+    });
+  };
+
+  return (
+    <div
+      onClick={handleLogin}
+      className="btn btn-block mt-2 border-[#1877f2] bg-[#1877f2] text-white shadow-[#1877f2]/30 hover:bg-[#1877f2]/90"
+    >
+      <span className="icon-[tabler--brand-facebook]"></span>
+      {isPending ? "Redirecting..." : "Connect Facebook"}
+    </div>
+  );
+};
+
+export default FacebookLogin;

--- a/components/Auth/GoogleLogin.tsx
+++ b/components/Auth/GoogleLogin.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { signInWithGoogle } from "@/actions/auth";
+import React, { useTransition } from "react";
+
+const GoogleLogin = () => {
+  const [isPending, startTransition] = useTransition();
+
+  const handleLogin = () => {
+    startTransition(async () => {
+      await signInWithGoogle();
+    });
+  };
+
+  return (
+    <div
+      onClick={handleLogin}
+      className="w-full btn mt-2 border-[#DB4437] bg-[#DB4437] text-white shadow-[#DB4437]/30 hover:bg-[#DB4437]/90"
+    >
+      <span className="icon-[tabler--brand-google]"></span>
+      {isPending ? "Redirecting..." : "Connect Google"}
+    </div>
+  );
+};
+
+export default GoogleLogin;

--- a/utils/getLinkedStatus.ts
+++ b/utils/getLinkedStatus.ts
@@ -1,0 +1,22 @@
+type IdentityProvider = "google" | "facebook" | "discord" | string;
+
+interface Identity {
+  provider: IdentityProvider;
+}
+
+interface LinkedStatus {
+  google: boolean;
+  facebook: boolean;
+  discord: boolean;
+}
+
+export const getLinkedStatus = (
+  identities: Identity[] | undefined | null
+): LinkedStatus => {
+  const linked = identities?.map((id) => id.provider) || [];
+  return {
+    google: linked.includes("google"),
+    facebook: linked.includes("facebook"),
+    discord: linked.includes("discord"),
+  };
+};


### PR DESCRIPTION
- Implemented `signInWithGoogle`, `signInWithFacebook`, and `signInWithDiscord` in server actions
- Created client components for GoogleLogin, FacebookLogin, and DiscordLogin
- Updated `Dashboard` page to show social login buttons conditionally based on linked status
- Added utility `getLinkedStatus` to check if social accounts are linked to the user